### PR TITLE
Establish compatibility with mini-css-extract-plugin@1.3.0

### DIFF
--- a/lib/SvgStorePlugin.js
+++ b/lib/SvgStorePlugin.js
@@ -197,9 +197,14 @@ class SvgStorePlugin {
      */
     replaceSpritePathsInModuleWithInterpolatedPaths(module, sprite) {
         switch (module.constructor.name) {
-            case 'CssModule':
-                module.content = sprite.replacePathsWithInterpolatedPaths(module.content);
+            case 'CssModule': {
+                const { content } = module;
+
+                const newContent = sprite.replacePathsWithInterpolatedPaths(content.toString());
+
+                module.content = Buffer.isBuffer(content) ? Buffer.from(newContent) : newContent;
                 break;
+            }
 
             case 'NormalModule': {
                 // Skip it if it wasn't changed


### PR DESCRIPTION
This is basically the fix from c0f46f883196678a3bb89ae33a0f632f07c77855 which establishes compatibility with `mini-css-extract-plugin@1.3` applied to the `6.0` branch.

I've manually tested this locally with `mini-css-extract-plugin@1.3.5` and also with `mini-css-extract-plugin@0.9.0`, which was the version we've been using with `external-svg-sprite-loader` before.

Fixes #93.