### PR TITLE
Replace paths with interpolated paths in all relevant properties of the source to prevent compatibility issues with other webpack plugins

### DIFF
--- a/lib/SvgStorePlugin.js
+++ b/lib/SvgStorePlugin.js
@@ -228,6 +228,9 @@ class SvgStorePlugin {
                         if (typeof source._value === 'string') {
                             source._value = sprite.replacePathsWithInterpolatedPaths(source._value);
                         }
+                        if (typeof source._valueAsString === 'string') {
+                            source._valueAsString = sprite.replacePathsWithInterpolatedPaths(source._valueAsString);
+                        }
                     }
                 }
                 break;


### PR DESCRIPTION
Hey @bensampaio,

I found a compatibiltiy issue with the [terser-webpack-plugin](https://github.com/webpack-contrib/terser-webpack-plugin).

When javascript files are minimized with the `terser-webpack-plugin` the hash of the generated sprite is not replaced in the compiled javascript files.

I've used the following webpack configuration

```js
const SvgStorePlugin = require('external-svg-sprite-loader');

module.exports = {
    optimization: {
       minimize: true
    },
    module: {
        rules: [
            {
                test: /\.(svg)$/,
                use: [{
                    loader: SvgStorePlugin.loader,
                    options: {
                        name: 'svg/sprite.[hash].svg',
                    },
                }],
            },
        ],
    },
    plugins: [
        new SvgStorePlugin({}),
    ],
};
```

I've have the following javascript file in my project:

```js
import './arrow.svg';
```

This leads to the following compiled javascript file:

```js
(()=>{var r={119:(r,t,e)=>{var o=e.p;r.exports={symbol:o+"svg/sprite.[hash].svg#icon-arrow-40850",view:o+"svg/sprite.[hash].svg#view-icon-arrow-40850",viewBox:"0 0 32 32"....
```

Could you take a look at the pull request? This should fix the above issue.

Thanks
